### PR TITLE
Add release automation (GitHub + Modrinth)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    uses: Ketket-s-Datapacks/.github/.github/workflows/datapack-release-reusable.yml@main
+    secrets:
+      MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}


### PR DESCRIPTION
This PR adds tag-based release automation.\n\nWhat it does:\n- Builds datapack zip on tag push (v*)\n- Publishes zip to GitHub Release\n- Uploads same zip to Modrinth\n\nRequired after merge:\n- Add repository secret MODRINTH_TOKEN